### PR TITLE
Add executive summaries to major rules

### DIFF
--- a/.cursor/rules/docs-openapi-spec.mdc
+++ b/.cursor/rules/docs-openapi-spec.mdc
@@ -82,3 +82,5 @@ The `docs/openapi.yaml` file must follow the structure below, derived from the "
                 - `format`: (e.g., uuid, email, int64) (Optional)
                 - `description`: (A brief explanation of the property) (Optional)
                 - `example`: (A sample value) (Optional)
+
+After outputting the full `docs/openapi.yaml` file, give a brief executive summary outlining the main endpoints or components you defined. This summary should not be included inside the YAML file itself.

--- a/.cursor/rules/docs-prd.mdc
+++ b/.cursor/rules/docs-prd.mdc
@@ -95,4 +95,6 @@ The `docs/PRD.md` file **MUST** be organized into the following eight sections. 
 
 4.  **Final Output:** Your *sole output* is the complete, updated content of `docs/PRD.md`.
 
+Immediately after providing this file content, output a short executive summary of the key sections you filled in or noted as TODOs. Keep this summary separate from the file content.
+
 **REMEMBER: Your output MUST ONLY be the full Markdown content for `docs/PRD.md`. Populate it strictly from `NOTES.md` (or specified primary source). Follow the 8-section structure. Insert `<!-- TODO: ... -->` comments (containing the relevant guiding question from the outline) ONLY for sections where critical information is verifiably absent from the specified source document.**

--- a/.cursor/rules/docs-structure.mdc
+++ b/.cursor/rules/docs-structure.mdc
@@ -39,4 +39,6 @@ Follow these steps:
 
 Your primary output is the complete content for the new `docs/STRUCTURE.md` file.
 
+After providing this file content, give a brief executive summary of the recommended structure so the user can quickly understand the key directories and their purposes. Keep this summary separate from the file content.
+
 **REMEMBER: The goal is to produce a `docs/STRUCTURE.md` file that serves as a practical guide for organizing files and directories within this project, promoting consistency and maintainability.**

--- a/.cursor/rules/docs-tech-stack.mdc
+++ b/.cursor/rules/docs-tech-stack.mdc
@@ -108,4 +108,6 @@ The `docs/TECH_STACK.md` file **MUST** be organized into the following ten secti
 
 4.  **Final Output:** Your *sole output* is the complete, updated content of `docs/TECH_STACK.md`.
 
+Immediately after providing this file content, output a short executive summary of the key sections you filled in or marked with TODOs. This summary should come after the file content and remain separate from it.
+
 **REMEMBER: Your output MUST ONLY be the full Markdown content for `docs/TECH_STACK.md`. Populate it strictly from `NOTES.md`, `docs/PRD.md`, and `docs/openapi.yaml`. Follow the 10-section structure. Insert `<!-- TODO: ... -->` comments (containing the guiding question from the outline) ONLY for sections where critical information is verifiably absent from all specified source documents.**

--- a/.cursor/rules/gh-task-plan.mdc
+++ b/.cursor/rules/gh-task-plan.mdc
@@ -116,7 +116,11 @@ Each commit title **MUST** follow semantic commit style (e.g., `feat: ...`, `fix
 
 ## IV. Post Task Plan Creation: Stop and Notify
 
-After posting the issue with the complete body via `gh issue create`, **STOP**. Notify the user of the newly created issue number or URL, then await their next instructions.
+After posting the issue with the complete body via `gh issue create`, **STOP**. Notify the user of the newly created issue number or URL.
+
+**Immediately after** posting, provide a short executive summary of the planned commits so the user can quickly review the steps. This summary must not be part of the issue body itself.
+
+After delivering the summary, await the user's next instructions.
 
 **REMEMBER: Your output is SOLELY the Markdown content of the issue body. This plan MUST be informed by `docs/` research, detail 2-5 verifiable commits, and rigorously include both automated tests and toggleable logging for each commit. Adhere strictly to the output format and communication constraints.**
 

--- a/.cursor/rules/project-update-rules.mdc
+++ b/.cursor/rules/project-update-rules.mdc
@@ -168,3 +168,5 @@ ide recommendations: [e.g., VS Code with specific extensions (check `.vscode/ext
 </template>
 
 Remember: the frontmatter for `_project.mdc` must have alwaysApply set to true.
+
+After outputting the completed `_project.mdc` file, provide a concise executive summary of the major sections you filled in or updated. Keep this summary separate from the file content so the user can quickly review the changes.

--- a/.cursor/rules/pull-request-create.mdc
+++ b/.cursor/rules/pull-request-create.mdc
@@ -67,4 +67,6 @@ Use this information before running the remaining steps.
 gh pr create --title "fix: Enforce normalized, dash-separated, lowercase labels" --body-file docs/pr/pr-body-file-fix-label-sanitization.md
 ```
 
+After creating the pull request, give a concise executive summary of the key changes and tests so reviewers know what to expect. Keep this summary separate from the PR body file.
+
 **REMEMBER: The objective is to create a meticulously prepared Pull Request. This includes clean commits, a descriptive title, a comprehensive body, and adherence to any project-specific pre-PR checks. A high-quality PR facilitates easier review and smoother integration.**

--- a/.cursor/rules/task-outline.mdc
+++ b/.cursor/rules/task-outline.mdc
@@ -32,5 +32,6 @@ Use this rule when the user requests help planning work but has not yet selected
 3. **Present Results**
    - Output a numbered list of the task options with their commit bullets.
    - Conclude with a short prompt asking the user to pick one option for further planning.
+   - After listing the options, provide a brief executive summary highlighting the main differences between the options. This summary should come after the list and not be included within any generated files.
 
 **REMEMBER: This rule only proposes outlines. Do not create any files or commit anything. Wait for the user to choose an option before generating a full task plan.**

--- a/.cursor/rules/task-plan.mdc
+++ b/.cursor/rules/task-plan.mdc
@@ -115,7 +115,12 @@ Each commit title **MUST** follow semantic commit style (e.g., `feat: ...`, `fix
 
 ## IV. Post Task Plan Creation: Stop and Notify
 
-Once the *entire content* of the `docs/tasks/<YYYY-MM-DD-HH-MM-task-name>.md` file has been generated (and is your sole output for this rule), **STOP**. Notify the user that the task plan is complete and available at the specified path, then await their next instructions.
+
+Once the *entire content* of the `docs/tasks/<YYYY-MM-DD-HH-MM-task-name>.md` file has been generated (and is your sole output for this rule), **STOP**. Notify the user that the task plan is complete and available at the specified path.
+
+**Immediately after** providing the file content, output a concise executive summary of all the planned commits so the user can quickly review the steps. This summary should not be part of the task plan file itself.
+
+After the summary, await the user's next instructions.
 
 **REMEMBER: Your output is SOLELY the Markdown content of the task plan file. This plan MUST be informed by `docs/` research, detail 2-5 verifiable commits, and rigorously include both automated tests and toggleable logging for each commit. Adhere strictly to the output format and communication constraints.**
 


### PR DESCRIPTION
## Summary
- update task planning rules to output an executive summary after generating the plan
- update GitHub issue planning rule to do the same
- add executive summary instructions to docs generation rules and project update rule
- update PR creation and task outline rules with short summaries

## Testing
- `npm test` *(fails: Error: no test specified)*