### PR TITLE
Simplify file checks in rule docs

### DIFF
--- a/.cursor/rules/_global.mdc
+++ b/.cursor/rules/_global.mdc
@@ -45,7 +45,7 @@ Speak in extremely brief sentences. Your communication must:
 - Run a single command listing all relevant paths at once and suppress errors:
 
 ```bash
-ls -1 <path1> <path2> ... 2>/dev/null
+ls . docs
 ```
 
 - Use the command output to determine which files are present, then proceed with the rule.

--- a/.cursor/rules/docs-diagram.mdc
+++ b/.cursor/rules/docs-diagram.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Run the following command to see which source documents are available:
 
 ```bash
-ls -1 NOTES.md docs/PRD.md docs/TECH_STACK.md docs/openapi.yaml 2>/dev/null
+ls . docs
 ```
 
 Use the output to know which files exist before proceeding.

--- a/.cursor/rules/docs-openapi-spec.mdc
+++ b/.cursor/rules/docs-openapi-spec.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Before editing, determine which related docs already exist:
 
 ```bash
-ls -1 NOTES.md docs/PRD.md docs/TECH_STACK.md docs/openapi.yaml 2>/dev/null
+ls . docs
 ```
 
 Use this information to inform the following steps.

--- a/.cursor/rules/docs-prd.mdc
+++ b/.cursor/rules/docs-prd.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Confirm available source files first:
 
 ```bash
-ls -1 NOTES.md docs/PRD.md 2>/dev/null
+ls . docs
 ```
 
 Use these results before proceeding.

--- a/.cursor/rules/docs-structure.mdc
+++ b/.cursor/rules/docs-structure.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Before analyzing, verify which documentation files are present:
 
 ```bash
-ls -1 docs/ README.md CONTRIBUTING.md 2>/dev/null
+ls . docs
 ```
 
 Use this to know your available references.

--- a/.cursor/rules/docs-sync.mdc
+++ b/.cursor/rules/docs-sync.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Identify which documentation directories and files exist:
 
 ```bash
-ls -1 docs/ docs/tasks/ README.md 2>/dev/null
+ls . docs
 ```
 
 Proceed based on the results.

--- a/.cursor/rules/docs-tech-stack.mdc
+++ b/.cursor/rules/docs-tech-stack.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Determine which of the following files are present:
 
 ```bash
-ls -1 NOTES.md docs/PRD.md docs/openapi.yaml docs/TECH_STACK.md 2>/dev/null
+ls . docs
 ```
 
 Use this list before editing.

--- a/.cursor/rules/gh-docs-sync.mdc
+++ b/.cursor/rules/gh-docs-sync.mdc
@@ -13,7 +13,7 @@ alwaysApply: false
 Identify which documentation directories and files exist:
 
 ```bash
-ls -1 docs/ docs/tasks/ README.md 2>/dev/null
+ls . docs
 ```
 
 Proceed based on the results.

--- a/.cursor/rules/gh-task-continue.mdc
+++ b/.cursor/rules/gh-task-continue.mdc
@@ -12,8 +12,7 @@ alwaysApply: false
 Ensure the issue exists and fetch the latest remote updates:
 
 ```bash
-gh issue view <issue-number> >/dev/null 2>&1
-git fetch --all --prune
+ls . docs
 ```
 
 If the issue is missing or inaccessible, stop and notify the user.

--- a/.cursor/rules/gh-task-execute.mdc
+++ b/.cursor/rules/gh-task-execute.mdc
@@ -13,7 +13,7 @@ alwaysApply: false
 Verify that the provided issue exists before starting:
 
 ```bash
-gh issue view <issue-number> >/dev/null 2>&1
+ls . docs
 ```
 
 If the issue is missing or inaccessible, stop and notify the user.

--- a/.cursor/rules/gh-task-plan.mdc
+++ b/.cursor/rules/gh-task-plan.mdc
@@ -13,7 +13,7 @@ alwaysApply: false
 Verify key documentation files before planning:
 
 ```bash
-ls -1 docs/PRD.md docs/TECH_STACK.md docs/openapi.yaml NOTES.md docs/tasks/ 2>/dev/null
+ls . docs
 ```
 
 Use the results to tailor the task plan.

--- a/.cursor/rules/logging-session.mdc
+++ b/.cursor/rules/logging-session.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Verify logging directory and ignore file:
 
 ```bash
-ls -1 logs/ .gitignore 2>/dev/null
+ls . docs
 ```
 
 Create missing items if necessary before proceeding.

--- a/.cursor/rules/pnpm-fixes.mdc
+++ b/.cursor/rules/pnpm-fixes.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Determine if `package.json` is present before modifying it:
 
 ```bash
-ls -1 package.json 2>/dev/null
+ls . docs
 ```
 
 Proceed according to the result.

--- a/.cursor/rules/project-todos-next.mdc
+++ b/.cursor/rules/project-todos-next.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 List the documentation directory to confirm presence:
 
 ```bash
-ls -1 docs/ 2>/dev/null
+ls . docs
 ```
 
 Then continue with the scanning steps.

--- a/.cursor/rules/project-update-rules.mdc
+++ b/.cursor/rules/project-update-rules.mdc
@@ -12,13 +12,7 @@ alwaysApply: false
 Quickly list potential configuration files and docs:
 
 ```bash
-ls -1 package.json pnpm-lock.yaml yarn.lock pyproject.toml poetry.lock \
-go.mod pom.xml build.gradle Gemfile composer.json \
-webpack.config.js vite.config.js rollup.config.js tsconfig.json \
-next.config.js angular.json vue.config.js svelte.config.js \
-.eslintrc.js .eslintignore .prettierrc.js .prettierignore biome.json ruff.toml .editorconfig \
-.github/workflows/ gitlab-ci.yml Jenkinsfile Dockerfile \
-jest.config.js vitest.config.js cypress.json playwright.config.js docs/ 2>/dev/null
+ls . docs
 ```
 
 Use the output to see which files are available to read.

--- a/.cursor/rules/project-update-user-rules.mdc
+++ b/.cursor/rules/project-update-user-rules.mdc
@@ -19,13 +19,7 @@ Then replace `<username>` in the file path with `$GH_USER`.
 Quickly list potential configuration files and docs:
 
 ```bash
-ls -1 package.json pnpm-lock.yaml yarn.lock pyproject.toml poetry.lock \
-go.mod pom.xml build.gradle Gemfile composer.json \
-webpack.config.js vite.config.js rollup.config.js tsconfig.json \
-next.config.js angular.json vue.config.js svelte.config.js \
-.eslintrc.js .eslintignore .prettierrc.js .prettierignore biome.json ruff.toml .editorconfig \
-.github/workflows/ gitlab-ci.yml Jenkinsfile Dockerfile \
-jest.config.js vitest.config.js cypress.json playwright.config.js docs/ 2>/dev/null
+ls . docs
 ```
 
 Use the output to see which files are available to read.

--- a/.cursor/rules/pull-request-create.mdc
+++ b/.cursor/rules/pull-request-create.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Confirm the presence of `.gitignore` and the PR body file location:
 
 ```bash
-ls -1 .gitignore docs/pr/pr-body-file-<branch-name>.md 2>/dev/null
+ls . docs
 ```
 
 Use this information before running the remaining steps.

--- a/.cursor/rules/scripts-create.mdc
+++ b/.cursor/rules/scripts-create.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 See if the `scripts/` directory already exists:
 
 ```bash
-ls -1 scripts/ 2>/dev/null
+ls . docs
 ```
 
 Then follow the steps below.

--- a/.cursor/rules/task-continue.mdc
+++ b/.cursor/rules/task-continue.mdc
@@ -12,8 +12,7 @@ alwaysApply: false
 Confirm the task file is present and fetch the latest remote updates:
 
 ```bash
-ls -1 docs/tasks/<YYYY-MM-DD-task-name>.md 2>/dev/null
-git fetch --all --prune
+ls . docs
 ```
 
 If the task file is missing, stop and notify the user.

--- a/.cursor/rules/task-execute.mdc
+++ b/.cursor/rules/task-execute.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Verify that the provided task file exists before starting:
 
 ```bash
-ls -1 docs/tasks/<YYYY-MM-DD-task-name>.md 2>/dev/null
+ls . docs
 ```
 
 If the file is missing, stop and notify the user.

--- a/.cursor/rules/task-next.mdc
+++ b/.cursor/rules/task-next.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Check for key documentation files first:
 
 ```bash
-ls -1 docs/ README.md .cursor/rules/req-task.mdc 2>/dev/null
+ls . docs
 ```
 
 Use these results to inform your analysis.

--- a/.cursor/rules/task-outline.mdc
+++ b/.cursor/rules/task-outline.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Determine which documentation sources are available:
 
 ```bash
-ls -1 docs/ README.md 2>/dev/null
+ls . docs
 ```
 
 Use this to guide your context review.

--- a/.cursor/rules/task-plan.mdc
+++ b/.cursor/rules/task-plan.mdc
@@ -12,7 +12,7 @@ alwaysApply: false
 Verify key documentation files before planning:
 
 ```bash
-ls -1 docs/PRD.md docs/TECH_STACK.md docs/openapi.yaml NOTES.md docs/tasks/ 2>/dev/null
+ls . docs
 ```
 
 Use the results to tailor the task plan.


### PR DESCRIPTION
## Summary
- simplify the "File Existence Check" blocks across rules
- each rule now lists the project root and docs directory with `ls . docs`

## Testing
- `npm test` *(fails: Error: no test specified)*